### PR TITLE
Fix first-run check

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -308,10 +308,10 @@ module.exports = {
   },
   isFirstRun() {
     try {
-      fs.statSync(path.join(module.exports.getInstallerDir(), "version.json"));
-      return true;
-    }catch (e) {
+      fs.statSync(module.exports.getInstallerDir());
       return false;
+    }catch (e) {
+      return true;
     }
   },
   onFirstRun(whatToDo) {


### PR DESCRIPTION
@fjvallarino  @ahmedalsudani  This check was reversed.  If the version file exists, it is NOT the first run.