### PR TITLE
Add a high level timeout on network requests

### DIFF
--- a/network.js
+++ b/network.js
@@ -115,7 +115,10 @@ module.exports = {
       });
     }
 
-    return new Promise(tryDownload);
+    return new Promise((resolve, reject)=>{
+      setTimeout(()=>{reject({ message: "Request timed out", error: url })}, 1000 * 60 * 20);
+      tryDownload(resolve, reject);
+    });
   },
   registerObserver(fn) {
     observers.push(fn);


### PR DESCRIPTION
When the network connection is closed, we're not always getting "close" or "error"
events on either the socket or the response.
@ahmedalsudani please review