### PR TITLE
Always use forward slash for url path separator

### DIFF
--- a/network.js
+++ b/network.js
@@ -52,7 +52,7 @@ module.exports = {
     downloadStats[url] = {tries: 0, bytesExpected: 0, bytesReceived: 0};
 
     function tryDownload(resolve, reject) {
-      var tempPath = path.join(platform.getTempDir(), urlParse(url).pathname.split(path.sep).pop()),
+      var tempPath = path.join(platform.getTempDir(), urlParse(url).pathname.split("/").pop()),
       file = fs.createWriteStream(tempPath);
 
       downloadStats[url].tries += 1;


### PR DESCRIPTION
@ahmedalsudani @fjvallarino I found this bug when using a long pathname to the staging tar.gz files on an auto-upgrade test.  