### PR TITLE
Use copySync+removeSync from fs-extra instead of fs.rename

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -318,14 +318,15 @@ module.exports = {
   },
   renameFile(oldName, newName) {
     return new Promise((resolve, reject)=>{
-      fs.rename(oldName, newName, (err)=>{
-        if(!err) {
-          resolve();
-        }
-        else {
-          reject({ message: "Error renaming file", error: err });
-        }
-      });
+      try {
+        fs.copySync(oldName, newName);
+        fs.removeSync(oldName);
+        resolve();
+      }
+      catch (err) {
+        var message = "Error renaming " + oldName + " to " + newName;
+        reject({ message: message, userFriendlyMessage: message, error: err });
+      }
     });
   },
   deleteRecursively(path) {


### PR DESCRIPTION
Use copySync+removeSync from fs-extra instead of fs.rename when moving files, to avoid issues when Temp directory and %APPDATA% are in different file systems (Windows only)

@tejohnso @ahmedalsudani please review