### PR TITLE
Remove quotation marks from killJava function

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -130,7 +130,7 @@ module.exports = {
       return module.exports.spawn("taskkill /f /im javaw.exe");
     }
     else {
-      return module.exports.spawn("pkill -f 'Rise.*jar'");
+      return module.exports.spawn("pkill -f Rise.*jar");
     }
   },
   killInstaller() {


### PR DESCRIPTION
Remove quotation marks from killJava function (internal spawn function does not handle them the same way shell would)

@tejohnso @ahmedalsudani please review