### PR TITLE
Pass original-fs to rimraf

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -345,7 +345,7 @@ module.exports = {
     });
   },
   callRimraf(path, cb) {
-    rimraf(path, require("original-fs"), cb);
+    rimraf(path, fs, cb);
   },
   callMkdirp(path, cb) {
     mkdirp(path, cb);

--- a/platform.js
+++ b/platform.js
@@ -345,7 +345,7 @@ module.exports = {
     });
   },
   callRimraf(path, cb) {
-    rimraf(path, cb);
+    rimraf(path, require("original-fs"), cb);
   },
   callMkdirp(path, cb) {
     mkdirp(path, cb);


### PR DESCRIPTION
@ahmedalsudani @fjvallarino using fs-extra didn't work on my test.  And there's really no reason why it should work because fs-extra [also uses rimraf for its remove()](https://github.com/jprichardson/node-fs-extra/blob/master/lib/remove/index.js#L8) functionality.  