### PR TITLE
Add error handling to start process

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -96,7 +96,7 @@ module.exports = {
     });
   },
   startProcess(command, args, tries) {
-    if (typeof tries === "undefined") {tries = 3;}
+    if (tries === undefined || tries === null) {tries = 3;}
     if (tries <= 0) {return;}
     tries -= 1;
 

--- a/platform.js
+++ b/platform.js
@@ -95,12 +95,23 @@ module.exports = {
       }, milliseconds);
     });
   },
-  startProcess(command, args) {
-    childProcess.spawn(command, args, {
-      cwd: path.dirname(command),
-      stdio: "ignore",
-      detached: true
-    }).unref();
+  startProcess(command, args, tries) {
+    if (typeof tries === "undefined") {tries = 3;}
+    if (tries <= 0) {return;}
+    tries -= 1;
+
+    try {
+      childProcess.spawn(command, args, {
+        cwd: path.dirname(command),
+        stdio: "ignore",
+        detached: true
+      }).unref();
+    } catch(err) {
+      if (tries === 0) {throw err;}
+      setTimeout(()=>{
+        module.exports.startProcess(command, args, tries);
+      }, 2000);
+    }
   },
   spawn(command, args, timeout, tries) {
     if (tries === undefined) {tries = 1;}

--- a/platform.js
+++ b/platform.js
@@ -107,7 +107,7 @@ module.exports = {
         detached: true
       }).unref();
     } catch(err) {
-      if (tries === 0) {throw err;}
+      if (tries <= 0) {throw err;}
       setTimeout(()=>{
         module.exports.startProcess(command, args, tries);
       }, 2000);

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -78,6 +78,27 @@ describe("platform", ()=>{
     assert.equal(childProcess.spawn.lastCall.args[2].detached, true);
   });
 
+  it("starts a detached child process after a couple of failures", function() {
+    var intervalHandler,
+    expectedCallCount = 3;
+
+    this.timeout(8000);
+    mock(childProcess, "spawn")
+    .throwWith(new Error("1"))
+    .throwWith(new Error("2"))
+    .returnWith({ unref() {} });
+
+    return new Promise((res)=>{
+      platform.startProcess("ls", ["-a", "*"]);
+      intervalHandler = setInterval(()=>{
+        if (childProcess.spawn.callCount === expectedCallCount) {
+          clearInterval(intervalHandler);
+          res();
+        }
+      }, 500);
+    });
+  });
+
   it("kills Java on Windows", ()=>{
     mock(platform, "isWindows").returnWith(true);
     mock(platform, "spawn").resolveWith();


### PR DESCRIPTION
child_process.spawn throws for certain error types (eg EBUSY)
Try a few times before finally throwing.  
@ahmedalsudani please review