### PR TITLE
Don't expect child process events on explorer call

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -163,12 +163,11 @@ module.exports = {
   },
   launchExplorer() {
     if (module.exports.isWindows() && module.exports.getWindowsVersion() !== "7") {
-      return module.exports.spawn("cmd", ["/c", "explorer"], 500)
-      .catch((err)=>{
-        log.debug("explorer call does not emit on close: " + err);
-      });
-    } else {
-      return Promise.resolve();
+      try {
+        module.exports.startProcess("cmd", ["/c", "explorer"], 1);
+      } catch (err) {
+        log.debug("explorer launch error: " + err);
+      }
     }
   },
   getWindowsVersion() {

--- a/platform.js
+++ b/platform.js
@@ -163,7 +163,10 @@ module.exports = {
   },
   launchExplorer() {
     if (module.exports.isWindows() && module.exports.getWindowsVersion() !== "7") {
-      return module.exports.spawn("cmd", ["/c", "explorer"]);
+      return module.exports.spawn("cmd", ["/c", "explorer"], 500)
+      .catch((err)=>{
+        log.debug("explorer call does not emit on close: " + err);
+      });
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
@ahmedalsudani @fjvallarino I noticed this during testing.  It looks like quit works, but it wasn't.  It was actually crashing Electron due to an uncaught rejection.  For some reason `spawn explorer` emits `close` if explorer is already running (a file explorer will open).  If explorer is not running, nothing is emitted, and we get a timeout rejection.