### PR TITLE
Recover from null values set by old bug

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -17,6 +17,11 @@ module.exports = {
   setEndpoint(configObj) {
     if (!configObj) {return reset();}
 
+    // Recover from a bug that saved invalid configuration
+    if (configObj === "http:///:null") {
+      configObj = "";
+    }
+
     if (typeof configObj === "string") {
       configObj = urlParse(configObj);
     }
@@ -37,7 +42,7 @@ module.exports = {
     if (!configObj.href) {
       let authString = configObj.auth,
       port = configObj.port;
-      
+
       if (authString) {authString += "@"}
       if (port) {port = ":" + port}
 

--- a/test/unit/proxy.js
+++ b/test/unit/proxy.js
@@ -86,6 +86,12 @@ describe("proxy", ()=>{
     proxy.setEndpoint({hostname: ""});
     assert.equal(proxySetup.proxyFields.href, "http://");
   });
+
+  it("doesn't set http:///:null", ()=>{
+    proxy.setEndpoint("http:///:null");
+    assert.equal(proxySetup.proxyFields.href, "http://");
+  });
+
   it("sets endpoint from a string", ()=>{
     proxy.setEndpoint("http://u:p@test1234:80");
     assert.equal(proxySetup.proxyFields.hostname, "test1234");


### PR DESCRIPTION
@tejohnso @fjvallarino ready for review.

I reduced the scope of what I was initially trying to fix. This fix only ignores the case where the user left all fields empty and clicked save.