### PR TITLE
Create directories as needed in writeTextFileSync

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -245,6 +245,7 @@ module.exports = {
     log.debug("writing sync " + filePath);
 
     try {
+      mkdirp.sync(path.dirname(filePath));
       fs.writeFileSync(filePath, data);
     }
     catch (err) {

--- a/test/integration/platform.js
+++ b/test/integration/platform.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+const platform = require("../../platform.js");
+const fs = require("fs");
+const path = require("path");
+global.log = global.log || {debug(){}};
+
+describe("Platform", ()=>{
+  describe("writeTextFileSync", ()=>{
+    it("writes a file, creating directories as required", ()=>{
+      try {fs.unlinkSync(path.join(process.cwd(), "testdir1", "testdir2", "testfile"))}catch(e){}
+      try {fs.rmdir(path.join(process.cwd(), "testdir1", "testdir2"))}catch(e){}
+      try {fs.rmdir(path.join(process.cwd(), "testdir1"))}catch(e){}
+      assert.throws(fs.statSync.bind(null, path.join(process.cwd(), "testdir1")));
+
+      platform.writeTextFileSync(path.join(process.cwd(), "testdir1", "testdir2", "testfile"), "test-text");
+      assert.equal(fs.readFileSync(path.join(process.cwd(), "testdir1", "testdir2", "testfile")), "test-text");
+    });
+  });
+});


### PR DESCRIPTION
@fjvallarino please review - we aren't creating directories in the sync method as we do in the async method.