### PR TITLE
Feature/free disk space

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -416,12 +416,12 @@ module.exports = {
         });
       }
       else {
-        var lnxCommand = "df --block-size=K --output=avail " + dir;
+        var lnxCommand = "df -k " + dir + " | awk 'NR==2 {print $4}'";
 
         childProcess.exec(lnxCommand, (err, stdout)=>{
           if(err) { reject(err); }
 
-          resolve(Number(stdout.replace("K", "").split("\n")[1]) * 1024);
+          resolve(Number(stdout) * 1024);
         });
       }
     });

--- a/platform.js
+++ b/platform.js
@@ -403,10 +403,11 @@ module.exports = {
 
     return module.exports.spawn(command, args);
   },
-  getFreeDiskSpace() {
+  getFreeDiskSpace(dir) {
     return new Promise((resolve, reject)=>{
+      dir = (dir) ? dir : module.exports.getInstallDir();
       if(module.exports.isWindows()) {
-        var winCommand = "wmic LogicalDisk Where \"Name='DRIVE:'\" GET FreeSpace".replace("DRIVE", module.exports.getInstallDir().substr(0, 1));
+        var winCommand = "wmic LogicalDisk Where \"Name='DRIVE:'\" GET FreeSpace".replace("DRIVE", dir.substr(0, 1));
 
         childProcess.exec(winCommand, (err, stdout)=>{
           if(err) { reject(err); }
@@ -415,7 +416,7 @@ module.exports = {
         });
       }
       else {
-        var lnxCommand = "df --block-size=K --output=avail " + module.exports.getInstallDir();
+        var lnxCommand = "df --block-size=K --output=avail " + dir;
 
         childProcess.exec(lnxCommand, (err, stdout)=>{
           if(err) { reject(err); }

--- a/platform.js
+++ b/platform.js
@@ -403,9 +403,8 @@ module.exports = {
 
     return module.exports.spawn(command, args);
   },
-  getFreeDiskSpace(dir) {
+  getFreeDiskSpace(dir=module.exports.getInstallDir()) {
     return new Promise((resolve, reject)=>{
-      dir = (dir) ? dir : module.exports.getInstallDir();
       if(module.exports.isWindows()) {
         var winCommand = "wmic LogicalDisk Where \"Name='DRIVE:'\" GET FreeSpace".replace("DRIVE", dir.substr(0, 1));
 

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -400,6 +400,22 @@ describe("platform", ()=>{
     });
   });
 
+  it("returns free disk space with dir as parameter on linux", ()=>{
+    var installDir = "/home/rise/rvplayer";
+    var dir = "/home/rise/rvplayer/test";
+
+    mock(platform, "isWindows").returnWith(false);
+    mock(platform, "getInstallDir").returnWith(installDir);
+    mock(childProcess, "exec").callbackWith(null, diskSpaceOutputLnx);
+
+    return platform.getFreeDiskSpace(dir)
+    .then((space)=>{
+      assert(childProcess.exec.called);
+      assert.equal(childProcess.exec.lastCall.args[0], "df --block-size=K --output=avail " + dir);
+      assert.equal(space, 72231133184);
+    });
+  });
+
   it("returns free disk space on Linux", ()=>{
     var installDir = "/home/rise/rvplayer";
 
@@ -408,10 +424,10 @@ describe("platform", ()=>{
     mock(childProcess, "exec").callbackWith(null, diskSpaceOutputLnx);
 
     return platform.getFreeDiskSpace()
-    .then((space)=>{
+      .then((space)=>{
       assert(childProcess.exec.called);
-      assert.equal(childProcess.exec.lastCall.args[0], "df --block-size=K --output=avail " + installDir);
-      assert.equal(space, 72231133184);
+    assert.equal(childProcess.exec.lastCall.args[0], "df --block-size=K --output=avail " + installDir);
+    assert.equal(space, 72231133184);
     });
   });
 

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -13,8 +13,7 @@ var diskSpaceOutputWin =
 265906098176     `;
 
 var diskSpaceOutputLnx =
-`    Avail
-70538216K`;
+`70538216`;
 
 describe("platform", ()=>{
   beforeEach("setup mocks", ()=>{
@@ -411,7 +410,7 @@ describe("platform", ()=>{
     return platform.getFreeDiskSpace(dir)
     .then((space)=>{
       assert(childProcess.exec.called);
-      assert.equal(childProcess.exec.lastCall.args[0], "df --block-size=K --output=avail " + dir);
+      assert.equal(childProcess.exec.lastCall.args[0], "df -k " + dir + " | awk 'NR==2 {print $4}'");
       assert.equal(space, 72231133184);
     });
   });
@@ -426,7 +425,7 @@ describe("platform", ()=>{
     return platform.getFreeDiskSpace()
       .then((space)=>{
       assert(childProcess.exec.called);
-    assert.equal(childProcess.exec.lastCall.args[0], "df --block-size=K --output=avail " + installDir);
+    assert.equal(childProcess.exec.lastCall.args[0], "df -k " + installDir + " | awk 'NR==2 {print $4}'");
     assert.equal(space, 72231133184);
     });
   });


### PR DESCRIPTION
Changed the getFreeDiskSpace to accept a directory as parameter.
Changed the check for space to be unix compatible instead of only linux compatible. The check was not working on Mac OS which is Rise Cache development env.

@fjvallarino @tejohnso please review.