### PR TITLE
Use ip module to get local ip address

### DIFF
--- a/network.js
+++ b/network.js
@@ -179,7 +179,7 @@ module.exports = {
           }
         }
 
-        res(addresses.length === 0 ? null : addresses.join(","));
+        res(addresses.length === 0 ? null : addresses[0]);
       }
       catch (err) {
         res(null);


### PR DESCRIPTION
@tejohnso please review

We will have to update both rise-launcher-electron and rise-cache-v2 to use this version, otherwise the build process keeps getting rise-cache-v2's version. 