### PR TITLE
Don't throw when using setTimeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/platform.js
+++ b/platform.js
@@ -101,10 +101,13 @@ module.exports = {
         detached: true
       }).unref();
     } catch(err) {
-      if (tries <= 0) {throw err;}
-      setTimeout(()=>{
-        module.exports.startProcess(command, args, tries);
-      }, 2000);
+      if (tries <= 0) {
+        log.external("error starting process", require("util").inspect(err));
+      } else {
+        setTimeout(()=>{
+          module.exports.startProcess(command, args, tries);
+        }, 2000);
+      }
     }
   },
   spawn(command, args, timeout, tries) {


### PR DESCRIPTION
Errors thrown inside asynchronous functions will act like uncaught
errors.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch#Gotchas_when_throwing_errors

@fjvallarino FYI
@settinghead  / @stulees please review