### PR TITLE
Feature/failed log retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "express": "^4.13.4",
     "istanbul": "^0.4.0",
+    "lolex": "^1.5.2",
     "mocha": "^2.3.3",
     "mocha-junit-reporter": "^1.9.1",
     "simple-mock": "^0.4.1"

--- a/test/integration/external-logger-bigquery.js
+++ b/test/integration/external-logger-bigquery.js
@@ -1,7 +1,7 @@
 "use strict";
 var assert = require("assert"),
 extlogger = require("../../external-logger-bigquery.js")
-("testos", "testarch", "testversion", "testosdescription");
+("testos", "testarch", "testversion", "testosdescription", __dirname);
 
 describe("external logger bigquery", function() {
   it("logs to bigquery", function() {

--- a/test/unit/external-logger-bigquery.js
+++ b/test/unit/external-logger-bigquery.js
@@ -81,8 +81,8 @@ describe("external logger bigquery", function() {
       clock.uninstall();
       return new Promise((res, rej)=>{
         setTimeout(()=>{
-          assert.equal(Object.keys(extlogger.pendingEntries()).length, 0);
           assert.equal(bqClient.insert.callCount, 2);
+          assert.equal(Object.keys(extlogger.pendingEntries()).length, 0);
           res();
         }, 100);
       });


### PR DESCRIPTION
@stulees @rodrigopavezi @fjvallarino This adds external logging retry with disk persist.  So if a machine is offline or the network has issues, the BQ log insert will be retried.