### PR TITLE
Use latest node to fix intermittend timeout

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.1.0
+    version: 8.2.1
 dependencies:
   pre:
     - npm install -g istanbul

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
I traced the problem down to a [setImmediate call](https://github.com/sindresorhus/got/blob/master/index.js#L88) that ends up calling [mimic-response](https://github.com/sindresorhus/mimic-response/blob/master/index.js#L23) and in some cases the fromStream had already started reading.  In those cases the .read function gets replaced in the mimic-response script and *I think* that was causing the problem.  In all the cases where the problem occurred the .read was replaced, and it all the passing cases, .read was not replaced.

setImmediate has been improved and seems to correct the problem.  Could also be fixed due to constant libuv improvements.