### PR TITLE
Fix tests since init is not called immediately.

### DIFF
--- a/bq-controller.js
+++ b/bq-controller.js
@@ -2,7 +2,7 @@ module.exports = (projectName, dataSetName, filename, installPath)=>{
   var bqClient = require("./bq-client.js")(projectName, dataSetName),
     fs = require("fs"),
     installPath = installPath || require("os").homedir(),
-    failedLogEntries,
+    failedLogEntries = {},
     FAILED_FILE_PATH = require("path").join(installPath, filename),
     MAX_FAILED_LOG_QUEUE = 50,
     FAILED_LOG_QUEUE_PURGE_COUNT = 10,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
Failed entries should be an object so Object.keys can be used - even
before init() is called (for tests which don't call init).