### PR TITLE
Facilitate use of external logging through Logging Module

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@ path = require("path"),
 debugging = process.argv.slice(1).join(" ").indexOf("debug") > -1,
 debug = (debugging ? (msg)=>{console.log(msg);} : ()=>{});
 
-module.exports = (externalLogger, logFolder, logFilePrefix = "installer")=> {
+module.exports = (externalLogger, logFolder, from, logFilePrefix = "installer")=> {
   var uiWindow;
 
   function validUiWindow() {
@@ -105,9 +105,9 @@ module.exports = (externalLogger, logFolder, logFilePrefix = "installer")=> {
       if (externalLogger) {externalLogger.setDisplaySettings(settings);}
     },
     external(evt, detail, table) {
-      appendToLog(table || evt, detail);
+      appendToLog(evt, detail);
 
-      if (externalLogger) {externalLogger.log(table || evt, detail);}
+      if (externalLogger) {externalLogger.log(evt, detail, table, from);}
     },
     file(detail, userFriendlyMessage) {
       appendToLog(detail, userFriendlyMessage);

--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@ path = require("path"),
 debugging = process.argv.slice(1).join(" ").indexOf("debug") > -1,
 debug = (debugging ? (msg)=>{console.log(msg);} : ()=>{});
 
-module.exports = (externalLogger, logFolder, from, logFilePrefix = "installer")=> {
+module.exports = (externalLogger, logFolder, moduleName = "installer")=> {
   var uiWindow;
 
   function validUiWindow() {
@@ -37,7 +37,7 @@ module.exports = (externalLogger, logFolder, from, logFilePrefix = "installer")=
 
   function resetLogFiles(maxSize=0) {
     try {
-      [`${logFilePrefix}-events.log`,`${logFilePrefix}-detail.log`]
+      [`${moduleName}-events.log`,`${moduleName}-detail.log`]
       .forEach((str)=>{
         let filePath = path.join(logFolder, str);
         if (fs.statSync(filePath).size < maxSize) {return;}
@@ -54,8 +54,8 @@ module.exports = (externalLogger, logFolder, from, logFilePrefix = "installer")=
     if(!logFolder) return;
 
     try {
-      var eventsLog = path.join(logFolder, `${logFilePrefix}-events.log`);
-      var detailsLog = path.join(logFolder, `${logFilePrefix}-detail.log`);
+      var eventsLog = path.join(logFolder, `${moduleName}-events.log`);
+      var detailsLog = path.join(logFolder, `${moduleName}-detail.log`);
 
       if(!fileExists(logFolder)) {
         fs.mkdirSync(logFolder);
@@ -107,7 +107,7 @@ module.exports = (externalLogger, logFolder, from, logFilePrefix = "installer")=
     external(evt, detail, table) {
       appendToLog(evt, detail);
 
-      if (externalLogger) {externalLogger.log(evt, detail, table, from);}
+      if (externalLogger) {externalLogger.log(evt, detail, table, moduleName);}
     },
     file(detail, userFriendlyMessage) {
       appendToLog(detail, userFriendlyMessage);

--- a/logger.js
+++ b/logger.js
@@ -104,10 +104,10 @@ module.exports = (externalLogger, logFolder, logFilePrefix = "installer")=> {
     setDisplaySettings(settings) {
       if (externalLogger) {externalLogger.setDisplaySettings(settings);}
     },
-    external(evt, detail) {
-      appendToLog(evt, detail);
+    external(evt, detail, table) {
+      appendToLog(table || evt, detail);
 
-      if (externalLogger) {externalLogger.log(evt, detail);}
+      if (externalLogger) {externalLogger.log(table || evt, detail);}
     },
     file(detail, userFriendlyMessage) {
       appendToLog(detail, userFriendlyMessage);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "2.3.1",
+  "version": "2.2.2",
   "description": "",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
Log function within external logging in `common-display-module` uses different params (table, detail). External() uses `table` if passed but defaults to `evt` for now. 