### PR TITLE
Supply callback for fs.truncate

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -42,7 +42,7 @@ module.exports = (externalLogger, logFolder, moduleName = "unknownmodule")=> {
       .forEach((str)=>{
         let filePath = path.join(logFolder, str);
         if (fs.statSync(filePath).size < maxSize) {return;}
-        fs.truncate(filePath);
+        fs.truncate(filePath, err=>debug("could not truncate", filePath));
       });
     } catch(e) {debug(e.stack);}
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
## Description

Suppresses a "callback must be supplied" error in modern Electron / node.

## Motivation and Context
Windows Player using latest Electron

## How Has This Been Tested?
Unit+Integration

