### PR TITLE
Return "Windows" when Windows caption is NULL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rise-common-electron",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "GPL-3.0",
       "dependencies": {
         "fs-extra": "git+https://github.com/Rise-Vision/node-fs-extra",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/platform.js
+++ b/platform.js
@@ -228,7 +228,7 @@ module.exports = {
 
       if (splitCaption.length < 2) return DEFAULT;
 
-      return caption.toString().trim().split("=")[1];
+      return splitCaption[1];
     } catch (e) {
       log.error("Error getting Windows OS caption: " + e);
       return DEFAULT;

--- a/platform.js
+++ b/platform.js
@@ -217,12 +217,22 @@ module.exports = {
     }
   },
   getWindowsOSCaption() {
-    let captionArgs = ["os", "get", "Caption", "/format:list"];
-    const caption = childProcess.spawnSync("wmic", captionArgs).stdout;
+    const DEFAULT = "Microsoft Windows";
+    try {
+      let captionArgs = ["os", "get", "Caption", "/format:list"];
+      const caption = childProcess.spawnSync("wmic", captionArgs).stdout;
 
-    if (!caption) return "Windows";
+      if (!caption) return DEFAULT;
 
-    return caption.toString().trim().split("=")[1];
+      const splitCaption = caption.toString().trim().split("=");
+
+      if (splitCaption.length < 2) return DEFAULT;
+
+      return caption.toString().trim().split("=")[1];
+    } catch (e) {
+      log.error("Error getting Windows OS caption: " + e);
+      return DEFAULT;
+    }
   },
   readTextFile(path, options = {}) {
     let fsModule = options.inASAR ? electronFS : fs;

--- a/platform.js
+++ b/platform.js
@@ -220,7 +220,7 @@ module.exports = {
     let captionArgs = ["os", "get", "Caption", "/format:list"];
     const caption = childProcess.spawnSync("wmic", captionArgs).stdout;
 
-    if (!caption) return "";
+    if (!caption) return "Windows";
 
     return caption.toString().trim().split("=")[1];
   },

--- a/platform.js
+++ b/platform.js
@@ -230,7 +230,7 @@ module.exports = {
 
       return splitCaption[1];
     } catch (e) {
-      log.error("Error getting Windows OS caption: " + e);
+      log.file("Error getting Windows OS caption: " + e);
       return DEFAULT;
     }
   },

--- a/platform.js
+++ b/platform.js
@@ -217,11 +217,12 @@ module.exports = {
     }
   },
   getWindowsOSCaption() {
-    let captionArgs = ["os", "get", "Caption", "/format:list"],
-    caption = childProcess.spawnSync("wmic", captionArgs)
-    .stdout.toString().trim().split("=")[1];
+    let captionArgs = ["os", "get", "Caption", "/format:list"];
+    const caption = childProcess.spawnSync("wmic", captionArgs).stdout;
 
-    return  caption;
+    if (!caption) return "";
+
+    return caption.toString().trim().split("=")[1];
   },
   readTextFile(path, options = {}) {
     let fsModule = options.inASAR ? electronFS : fs;

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -628,15 +628,20 @@ describe("platform", ()=>{
   });
 
   it("Retrieves the windows os description", ()=>{
-    const osFlavor = "Microsoft Windows 10 Pro"
-    const mockResponse = `Caption=${osFlavor}`
+    const osFlavor = "Microsoft Windows 10 Pro";
+    const mockResponse = `Caption=${osFlavor}`;
     mock(childProcess, "spawnSync").returnWith({ stdout: mockResponse });
-    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows 10 Pro")
+    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows 10 Pro");
   });
 
   it("Retrieves a default windows os description", ()=>{
-    const mockResponse = "Microsoft Windows"
+    const mockResponse = "Microsoft Windows";
     mock(childProcess, "spawnSync").returnWith({ stdout: mockResponse });
-    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows")
+    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows");
+  });
+
+  it("Handles errors when retrieving windows os description", ()=>{
+    mock(childProcess, "spawnSync").throwWith(new Error("Command failed"));
+    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows");
   });
 });

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -626,4 +626,17 @@ describe("platform", ()=>{
     platform.launchExplorer();
     assert.deepEqual(platform.startProcess.lastCall.args[3].env, originalEnv);
   });
+
+  it("Retrieves the windows os description", ()=>{
+    const osFlavor = "Microsoft Windows 10 Pro"
+    const mockResponse = `Caption=${osFlavor}`
+    mock(childProcess, "spawnSync").returnWith({ stdout: mockResponse });
+    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows 10 Pro")
+  });
+
+  it("Retrieves a default windows os description", ()=>{
+    const mockResponse = "Microsoft Windows"
+    mock(childProcess, "spawnSync").returnWith({ stdout: mockResponse });
+    assert.equal(platform.getWindowsOSCaption(), "Microsoft Windows")
+  });
 });


### PR DESCRIPTION
## Description
Some Windows displays were showing incorrect data due to an issue when collecting one of the data points.

## Motivation and Context
We always need to have the correct Display data to show the correct configuration options.

## How Has This Been Tested?
I was able to reproduce the issue just by running a Windows Display locally, without needing to modify anything. After the fix, the correct display data was shown in the app.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced Windows OS identification to ensure a default name displays reliably when system details aren’t available, including improved error handling and validation checks.
  - Added new test cases to validate the functionality of the Windows OS description retrieval.

- **Chores**
  - Updated package version from 3.0.5 to 3.0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->