### PR TITLE
Get new windows installation mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/platform.js
+++ b/platform.js
@@ -234,6 +234,26 @@ module.exports = {
       return DEFAULT;
     }
   },
+  getWindowsInstallationMode() {
+    const DEFAULT = "Single";
+    try {
+      const localAppDataPath = path.join(process.env.LOCALAPPDATA, "rvplayer");
+      const programFilesPath = path.join(process.env[process.arch === "x64" ? "ProgramFiles" : "ProgramFiles(x86)"], "rvplayer");
+      
+      if (fs.existsSync(programFilesPath)) {
+        return "Multi";
+      }
+      
+      if (fs.existsSync(localAppDataPath)) {
+        return "Single";
+      }
+      
+      return DEFAULT;
+    } catch (e) {
+      log.file("Error getting Windows installation mode: " + e);
+      return DEFAULT;
+    }
+  },
   readTextFile(path, options = {}) {
     let fsModule = options.inASAR ? electronFS : fs;
 

--- a/platform.js
+++ b/platform.js
@@ -238,16 +238,16 @@ module.exports = {
     const DEFAULT = "Single";
     try {
       const localAppDataPath = path.join(process.env.LOCALAPPDATA, "rvplayer");
-      const programFilesPath = path.join(process.env[process.arch === "x64" ? "ProgramFiles" : "ProgramFiles(x86)"], "rvplayer");
-      
+      const programFilesPath = path.join(process.env[module.exports.getArch() === "x64" ? "ProgramFiles" : "ProgramFiles(x86)"], "rvplayer");
+
       if (fs.existsSync(programFilesPath)) {
         return "Multi";
       }
-      
+
       if (fs.existsSync(localAppDataPath)) {
         return "Single";
       }
-      
+
       return DEFAULT;
     } catch (e) {
       log.file("Error getting Windows installation mode: " + e);


### PR DESCRIPTION
## Description
We'll need to identify which type of installation the user chose in Windows, so I created a new function that returns that.

## Motivation and Context
With this new information, we’ll be able to make decisions specifically related to a particular type of installation.

## How Has This Been Tested?
The function was called from the Player in both types of installation, and it was verified whether the expected return was being received.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the application's detection of installation mode on Windows, ensuring more reliable behavior in both single-user and multi-user environments.

- **Bug Fixes**
  - Improved error handling in the installation mode detection method.

- **Tests**
  - Introduced a comprehensive test suite for the installation mode detection, covering various scenarios and ensuring correct behavior.

- **Chores**
  - Updated package version from 3.0.6 to 3.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->