### PR TITLE
Set cwd when launching explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rise-common-electron",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "GPL-3.0",
       "dependencies": {
         "fs-extra": "git+https://github.com/Rise-Vision/node-fs-extra",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -627,6 +627,28 @@ describe("platform", ()=>{
     assert.deepEqual(platform.startProcess.lastCall.args[3].env, originalEnv);
   });
 
+  it("launches explorer with the proper working directory when systemroot env var present", ()=>{
+    mock(platform, "isWindows").returnWith(true);
+    mock(platform, "getWindowsVersion").returnWith("10");
+    mock(platform, "startProcess").resolveWith();
+
+    process.env.SystemRoot = path.join("C:", "Windows");
+    platform.launchExplorer();
+    assert.deepEqual(platform.startProcess.lastCall.args[3].cwd, path.join("C:", "Windows"));
+  });
+
+  it("launches explorer with the proper working directory when systemroot env var not present", ()=>{
+    mock(platform, "isWindows").returnWith(true);
+    mock(platform, "getWindowsVersion").returnWith("10");
+    mock(platform, "startProcess").resolveWith();
+
+    delete process.env.SystemRoot;
+    mock(platform, "getCwd").returnWith(path.join("C:", "Some", "Subdir"));
+    mock(platform, "getCwdRoot").returnWith(`C:${path.sep}`);
+    platform.launchExplorer();
+    assert.deepEqual(platform.startProcess.lastCall.args[3].cwd, path.join("C:", "Windows"));
+  });
+
   it("Retrieves the windows os description", ()=>{
     const osFlavor = "Microsoft Windows 10 Pro";
     const mockResponse = `Caption=${osFlavor}`;


### PR DESCRIPTION
## Description
Explorer.exe shouldn't be run with the player's path as its working directory.

## Motivation and Context
Reliability and best practices

## How Has This Been Tested?
Directly on windows machine by running the player and quitting to confirm explorer restarts, and verified cwd in log file.  

## Release Plan:
- Immediate merge and set new version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new method to retrieve the root directory of the current working directory.
- **Bug Fixes**
	- Improved error logging and handling when launching processes and the file explorer.
	- Ensured the file explorer launches with the correct working directory on Windows systems.
- **Tests**
	- Added unit tests to verify file explorer launch behavior under different Windows environment conditions.
- **Chores**
	- Updated the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->