### PR TITLE
Feature/log details to file when using endpoint logging structure

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -54,20 +54,38 @@ module.exports = (externalLogger, logFolder, moduleName = "unknownmodule")=> {
     try {
       var eventsLog = path.join(logFolder, `${moduleName}-events.log`);
       var detailsLog = path.join(logFolder, `${moduleName}-detail.log`);
+
+      var detailsVal = "";
+      var userFriendlyMessageVal = userFriendlyMessage || "";
+
       // backwards compatible for installer and player modules
-      var detailsVal = (typeof detail === "string") ? detail : (detail && (detail.event_details || detail.eventDetails)) || "";
+      if(typeof detail === "string") {
+        detailsVal = detail;
+      }
+      else if(detail) {
+        const eventDetails = detail.event_details || detail.eventDetails || "";
+        const debugInfo = detail.debug_info || detail.debugInfo || "";
+        const debugInfoVal = (typeof debugInfo === "string") ? debugInfo : JSON.stringify(debugInfo);
+
+        if(!userFriendlyMessageVal) {
+          userFriendlyMessageVal = eventDetails || "";
+          detailsVal = debugInfoVal;
+        } else {
+          detailsVal = `${eventDetails}\n${debugInfoVal}`;
+        }
+      }
 
       if(!fileExists(logFolder)) {
         fs.mkdirSync(logFolder);
       }
 
-      if(userFriendlyMessage) {
-        fs.appendFileSync(eventsLog, getLogDatetime() + " - " + userFriendlyMessage + "\n");
+      if(userFriendlyMessageVal) {
+        fs.appendFileSync(eventsLog, getLogDatetime() + " - " + userFriendlyMessageVal + "\n");
       }
 
       if(detailsVal) {
-        if(userFriendlyMessage) {
-          fs.appendFileSync(detailsLog, getLogDatetime() + " - " + userFriendlyMessage + "\n");
+        if(userFriendlyMessageVal) {
+          fs.appendFileSync(detailsLog, getLogDatetime() + " - " + userFriendlyMessageVal + "\n");
         }
         else {
           fs.appendFileSync(detailsLog, getLogDatetime() + "\n");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-common-electron",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "",
   "main": "index.js",
   "author": "",

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -91,6 +91,34 @@ describe("Logger", ()=>{
     assert.equal(fs.appendFileSync.callCount, 3);
     assert(fs.appendFileSync.lastCall.args[1].includes("some-detail"));
   });
+
+  it("extracts detail from eventDetails and debugInfo", ()=>{
+    simpleMock.mock(fs, "statSync").throwWith("ENOENT test");
+    simpleMock.mock(fs, "truncate").returnWith();
+    simpleMock.mock(fs, "mkdirSync").returnWith();
+    simpleMock.mock(fs, "appendFileSync").returnWith();
+    require("../../logger.js")({}, "installDir").file({
+      "eventDetails": "some-detail",
+      "debugInfo": "some-debug-info"
+    }, "user-message");
+    assert.equal(fs.appendFileSync.callCount, 3);
+    assert(fs.appendFileSync.lastCall.args[1].includes("some-detail"));
+    assert(fs.appendFileSync.lastCall.args[1].includes("some-debug-info"));
+  });
+
+  it("separates eventDetails and debugInfo if userFriendlyMessage is not provided", ()=>{
+    simpleMock.mock(fs, "statSync").throwWith("ENOENT test");
+    simpleMock.mock(fs, "truncate").returnWith();
+    simpleMock.mock(fs, "mkdirSync").returnWith();
+    simpleMock.mock(fs, "appendFileSync").returnWith();
+    require("../../logger.js")({}, "installDir").file({
+      "eventDetails": "some-detail",
+      "debugInfo": "some-debug-info"
+    });
+    assert.equal(fs.appendFileSync.callCount, 3);
+    assert(fs.appendFileSync.calls[1].args[1].includes("some-detail"));
+    assert(fs.appendFileSync.calls[2].args[1].includes("some-debug-info"));
+  });
 });
 
 describe("launcher", ()=>{


### PR DESCRIPTION
## Description
Improve file logging in windows player, in particular, if an endpoint logging has been provided to these functions:

- If no user friendly message has been provided, use eventDetail as the user friendly message and the debug info as the detail.
- If a user friendly message was provided, use both eventDetail and debugInfo to provide the detail to the detailed log file.

## Motivation and Context
File logs are missing some information that is going into remote logs, which complicates local logging as one has to always check two logs for debugging, remote and local. This change makes information in local to contain the same level of detail as the one logged remotely.

## How Has This Been Tested?
Tested manually with a forced display control failure. File logging is now showing as expected.

## Release Plan:
To be released immediately.

#### Release Checklist Items Skipped?
No need to update documentation, no need to notify Support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the clarity and consistency of log messages and details in the logging system.
- **Tests**
  - Added new unit tests to verify correct handling of event details and debug information in log entries.
- **Chores**
  - Updated the package version to 3.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->